### PR TITLE
Remove unused variable warning

### DIFF
--- a/lib/sizeable.ex
+++ b/lib/sizeable.ex
@@ -83,10 +83,10 @@ defmodule Sizeable do
     result = Float.round(value / :math.pow(ceil, exponent), base)
 
     result = if Float.floor(result) == result do
-      result = round result
+      round result
     else
       result
-        |> Float.round(round)
+      |> Float.round(round)
     end
 
     {:ok, unit} = case bits do


### PR DESCRIPTION
There was a warning:
```
warning: variable result is unused
  lib/sizeable.ex:86
```