### PR TITLE
Add new ouput format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ The package can be installed as:
 
   1. Add `sizeable` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:sizeable, "~> 1.0.0"}]
-    end
-    ```
+  ```elixir
+  def deps do
+    [{:sizeable, "~> 1.0"}]
+  end
+  ```
 
   2. Ensure `sizeable` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:sizeable]]
-    end
-    ```
+  ```elixir
+  def application do
+    [applications: [:sizeable]]
+  end
+  ```
 
 ## Usage
 
@@ -39,13 +39,32 @@ Returns a human-readable string for the given numeric value.
 - `spacer`: the string that should be between the number and the unit. Defaults to `" "`.
 - `round`: the precision that the number should be rounded down to. Defaults to `2`.
 - `base`: the base for exponent calculation. `2` for binary-based numbers, any other Integer can be used. Defaults to `2`.
+- `output`: the ouput format to be used, possible options are :string, :list, :map. Defaults to :string.
 
 #### Example - Get file size for 1024 bytes
 
-    Sizeable.filesize(1024)
-    "1 KB"
+```elixir
+Sizeable.filesize(1024)
+"1 KB"
+```
 
 #### Example - Get bit-sized file size for 1024 bytes
 
-    Sizeable.filesize(1024, [bits: true]})
-    "8 Kb"
+```elixir
+Sizeable.filesize(1024, bits: true)
+"8 Kb"
+```
+
+#### Example - Get output format as list
+
+```elixir
+Sizeable.filesize(1024, output: :list)
+[1, "KB"]
+```
+
+#### Example - Get output format as map
+
+```elixir
+Sizeable.filesize(1024, output: :map)
+%{result: 1, unit: "KB"}
+```

--- a/lib/sizeable.ex
+++ b/lib/sizeable.ex
@@ -21,7 +21,7 @@ defmodule Sizeable do
   end
 
   def filesize(value, options) when is_bitstring(value) do
-    case value |> Integer.parse() do
+    case Integer.parse(value) do
       {parsed, _rem} -> filesize(parsed, options)
       :error -> raise "Value is not a Number"
     end
@@ -93,8 +93,7 @@ defmodule Sizeable do
     result = if Float.floor(result) == result do
       round result
     else
-      result
-      |> Float.round(round)
+      Float.round(result, round)
     end
 
     {:ok, unit} = case bits do

--- a/lib/sizeable.ex
+++ b/lib/sizeable.ex
@@ -1,13 +1,12 @@
 defmodule Sizeable do
-
   @moduledoc """
   A library to make file sizes human-readable
   """
 
   require Logger
 
-  @bits ["b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"]
-	@bytes ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+  @bits ~w(b Kb Mb Gb Tb Pb Eb Zb Yb)
+  @bytes ~w(B KB MB GB TB PB EB ZB YB)
 
   @doc """
   see `filesize(value, options)`
@@ -21,7 +20,7 @@ defmodule Sizeable do
     filesize(value, Map.to_list(options))
   end
 
-  def filesize(value,options) when is_bitstring(value) do
+  def filesize(value, options) when is_bitstring(value) do
     case value |> Integer.parse() do
       {parsed, _rem} -> filesize(parsed, options)
       :error -> raise "Value is not a Number"
@@ -36,12 +35,14 @@ defmodule Sizeable do
   def filesize(0.0, options) do
     spacer = Keyword.get(options, :spacer, " ")
     bits = Keyword.get(options, :bits, false)
+    output = Keyword.get(options, :output, :string)
 
     {:ok, unit} = case bits do
       true -> Enum.fetch(@bits, 0)
       false -> Enum.fetch(@bytes, 0)
     end
-    Enum.join([0,unit], spacer)
+
+    filesize_output(output, 0, unit, spacer)
   end
 
   @doc """
@@ -58,18 +59,19 @@ defmodule Sizeable do
   - `spacer`: the string that should be between the number and the unit. Defaults to `" "`.
   - `round`: the precision that the number should be rounded down to. Defaults to `2`.
   - `base`: the base for exponent calculation. `2` for binary-based numbers, any other Integer can be used. Defaults to `2`.
+  - `output`: the ouput format to be used, possible options are :string, :list, :map. Defaults to :string.
 
   ## Example - Get bit-sized file size for 1024 byte
 
-      Sizeable.filesize(1024, [bits: true])
-      "8 Kb"
+    Sizeable.filesize(1024, bits: true)
+    "8 Kb"
   """
-
   def filesize(value, options) when (is_float(value) and is_list(options)) do
     bits = Keyword.get(options, :bits, false)
     base = Keyword.get(options, :base, 2)
     spacer = Keyword.get(options, :spacer, " ")
     round = Keyword.get(options, :round, 2)
+    output = Keyword.get(options, :output, :string)
 
     ceil = if base > 2 do 1000 else 1024 end
     neg = value < 0
@@ -100,12 +102,12 @@ defmodule Sizeable do
       false -> Enum.fetch(@bytes, exponent)
     end
 
-    case neg do
-      true ->
-        "-" <> Enum.join([result,unit], spacer)
-      false ->
-        Enum.join([result,unit], spacer)
+    result = case neg do
+      true -> result * -1
+      false -> result
     end
+
+    filesize_output(output, result, unit, spacer)
   end
 
   def filesize(_value, options) when is_list(options) do
@@ -116,4 +118,12 @@ defmodule Sizeable do
     raise "Invalid Options Argument"
   end
 
+  def filesize_output(output, result, unit, spacer) do
+    case output do
+      :string -> Enum.join([result, unit], spacer)
+      :list -> [result, unit]
+      :map -> %{result: result, unit: unit}
+      _ -> raise "Invalid `#{output}` output value, possible options are :string, :list, :map"
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Sizeable.Mixfile do
 
   def project do
     [app: :sizeable,
-     version: "1.0.0",
+     version: "1.0.1",
      elixir: "~> 1.1",
      description: "An Elixir library to make file sizes human-readable.",
      package: package(),

--- a/test/sizeable_test.exs
+++ b/test/sizeable_test.exs
@@ -18,7 +18,6 @@ defmodule SizeableTest do
   @fail_options {:bits, true}
 
   # Test for erroneous values
-
   test "fail" do
     assert_raise RuntimeError, "Value is not a Number", fn ->
       Sizeable.filesize(@fail_value_string)
@@ -51,19 +50,19 @@ defmodule SizeableTest do
   end
 
   test "500 B bits" do
-    assert Sizeable.filesize(@kilobit, [bits: true]) == "3.91 Kb"
+    assert Sizeable.filesize(@kilobit, bits: true) == "3.91 Kb"
   end
 
   test "500 B bits base10" do
-    assert Sizeable.filesize(@kilobit, [bits: true, base: 10]) == "4 Kb"
+    assert Sizeable.filesize(@kilobit, bits: true, base: 10) == "4 Kb"
   end
 
   test "500 B bits base10 round" do
-    assert Sizeable.filesize(@kilobit, [bits: true, base: 10, round: 1]) == "4 Kb"
+    assert Sizeable.filesize(@kilobit, bits: true, base: 10, round: 1) == "4 Kb"
   end
 
   test "500 B bits round" do
-    assert Sizeable.filesize(@kilobit, [bits: true, round: 1]) == "3.9 Kb"
+    assert Sizeable.filesize(@kilobit, bits: true, round: 1) == "3.9 Kb"
   end
 
   # Tests for Kilobyte values
@@ -72,19 +71,19 @@ defmodule SizeableTest do
   end
 
   test "1 KB round" do
-    assert Sizeable.filesize(@kilobyte, [round: 1]) == "1 KB"
+    assert Sizeable.filesize(@kilobyte, round: 1) == "1 KB"
   end
 
   test "1 KB round spacer" do
-    assert Sizeable.filesize(@kilobyte, [round: 1, spacer: ""]) == "1KB"
+    assert Sizeable.filesize(@kilobyte, round: 1, spacer: "") == "1KB"
   end
 
   test "1 KB bits" do
-    assert Sizeable.filesize(@kilobyte, [bits: true]) == "8 Kb"
+    assert Sizeable.filesize(@kilobyte, bits: true) == "8 Kb"
   end
 
   test "1 KB bits round" do
-    assert Sizeable.filesize(@kilobyte, [bits: true, round: 1]) == "8 Kb"
+    assert Sizeable.filesize(@kilobyte, bits: true, round: 1) == "8 Kb"
   end
 
   # Tests for negative values
@@ -93,36 +92,36 @@ defmodule SizeableTest do
   end
 
   test "neg round" do
-    assert Sizeable.filesize(@neg, [round: 1]) == "-1 KB"
+    assert Sizeable.filesize(@neg, round: 1) == "-1 KB"
   end
 
   test "neg round spacer" do
-    assert Sizeable.filesize(@neg, [round: 1, spacer: ""]) == "-1KB"
+    assert Sizeable.filesize(@neg, round: 1, spacer: "") == "-1KB"
   end
 
   test "neg bits" do
-    assert Sizeable.filesize(@neg, [bits: true]) == "-8 Kb"
+    assert Sizeable.filesize(@neg, bits: true) == "-8 Kb"
   end
 
   test "neg round bits" do
-    assert Sizeable.filesize(@neg, [bits: true, round: 1]) == "-8 Kb"
+    assert Sizeable.filesize(@neg, bits: true, round: 1) == "-8 Kb"
   end
-
 
   # Tests for 0
   test "zero round" do
-    assert Sizeable.filesize(@zero, %{round: 1}) == "0 B"
+    assert Sizeable.filesize(@zero, round: 1) == "0 B"
   end
 
   test "zero round spacer" do
-    assert Sizeable.filesize(@zero, [round: 1, spacer: ""]) == "0B"
+    assert Sizeable.filesize(@zero, round: 1, spacer: "") == "0B"
   end
 
   test "zero bits" do
-    assert Sizeable.filesize(@zero, [bits: true]) == "0 b"
+    assert Sizeable.filesize(@zero, bits: true) == "0 b"
   end
+
   test "zero bits round" do
-    assert Sizeable.filesize(@zero, [bits: true, round: 1]) == "0 b"
+    assert Sizeable.filesize(@zero, bits: true, round: 1) == "0 b"
   end
 
   # Tests for the 1023 edge case
@@ -140,18 +139,40 @@ defmodule SizeableTest do
   end
 
   test "byte round" do
-    assert Sizeable.filesize(@byte, [round: 1]) == "1 B"
+    assert Sizeable.filesize(@byte, round: 1) == "1 B"
   end
+
   test "byte round spacer" do
-    assert Sizeable.filesize(@byte, [round: 1, spacer: ""]) == "1B"
+    assert Sizeable.filesize(@byte, round: 1, spacer: "") == "1B"
   end
 
   test "byte bits" do
-    assert Sizeable.filesize(@byte, [bits: true]) == "8 b"
+    assert Sizeable.filesize(@byte, bits: true) == "8 b"
   end
 
   test "byte bits round" do
-    assert Sizeable.filesize(@byte, [bits: true, round: 1]) == "8 b"
+    assert Sizeable.filesize(@byte, bits: true, round: 1) == "8 b"
   end
 
+  # Test for output formats
+  test "ouput string" do
+    assert Sizeable.filesize(@kilobyte, output: :string) == "1 KB"
+    assert Sizeable.filesize(@zero, ouput: :string) == "0 B"
+  end
+
+  test "ouput list" do
+    assert Sizeable.filesize(@kilobyte, output: :list) == [1, "KB"]
+    assert Sizeable.filesize(@zero, output: :list) == [0, "B"]
+  end
+
+  test "output map" do
+    assert Sizeable.filesize(@kilobyte, output: :map) == %{result: 1, unit: "KB"}
+    assert Sizeable.filesize(@zero, output: :map) == %{result: 0, unit: "B"}
+  end
+
+  test "ouput invalid" do
+    assert_raise RuntimeError, "Invalid `array` output value, possible options are :string, :list, :map", fn ->
+      Sizeable.filesize(@kilobyte, output: :array)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes is useful to get only the result value or the unit or both of them to improve the formatting so I have added a new `output` option to allow this.

The possible values for `output` are `:string`, `:list`,  and `:map`. By default `:string` is used making it compatible with the previous implementation without `output` option.

The output formats are the following:
* `string`: `"1 KB"`.
* `list`: `[1, "KB"]`.
* `map`: `%{result: 1, unit: "KB"}`.