### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,27 @@
-/_build
-/cover
-/deps
-/doc
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+sizeable-*.tar
+
+
+# Temporary files for e.g. tests
+/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: elixir
-elixir:
-  - 1.1
-  - 1.2
-  - 1.3
-after_script:
-  - mix deps.get --only docs
-  - MIX_ENV=docs mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Sizeable ![Build status](https://travis-ci.org/arvidkahl/sizeable.svg) [![Inline docs](http://inch-ci.org/github/arvidkahl/sizeable.svg)](http://inch-ci.org/github/arvidkahl/sizeable)
+# Sizeable
+
+<!-- MDOC !-->
+
+[![Module Version](https://img.shields.io/hexpm/v/sizeable.svg)](https://hex.pm/packages/sizeable)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/sizeable/)
+[![Total Download](https://img.shields.io/hexpm/dt/sizeable.svg)](https://hex.pm/packages/sizeable)
+[![License](https://img.shields.io/hexpm/l/sizeable.svg)](https://github.com/arvidkahl/sizeable/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/arvidkahl/sizeable.svg)](https://github.com/arvidkahl/sizeable/commits/master)
 
 An Elixir library to make file sizes human-readable.
 
@@ -6,65 +14,60 @@ An Elixir library to make file sizes human-readable.
 
 The package can be installed as:
 
-  1. Add `sizeable` to your list of dependencies in `mix.exs`:
+1.  Add `:sizeable` to your list of dependencies in `mix.exs`:
 
-  ```elixir
-  def deps do
-    [{:sizeable, "~> 1.0"}]
-  end
-  ```
+    ```elixir
+    def deps do
+      [
+        {:sizeable, "~> 1.0"}
+      ]
+    end
+    ```
 
-  2. Ensure `sizeable` is started before your application:
+2.  Ensure `sizeable` is started before your application if you're using Elixir 1.3 or lower:
 
-  ```elixir
-  def application do
-    [applications: [:sizeable]]
-  end
-  ```
+    ```elixir
+    def application do
+      [
+        applications: [:sizeable]
+      ]
+    end
+    ```
 
 ## Usage
 
-### `Sizeable.filesize(value, options \\ [])`
-
-Returns a human-readable string for the given numeric value.
-
-#### Arguments:
-
-- `value` (Integer/Float/String) representing the filesize to be converted.
-- `options` (Struct) representing the options to determine base, rounding and units.
-
-#### Options:
-
-- `bits`: `true` if the result should be in bits, `false` if in bytes. Defaults to `false`.
-- `spacer`: the string that should be between the number and the unit. Defaults to `" "`.
-- `round`: the precision that the number should be rounded down to. Defaults to `2`.
-- `base`: the base for exponent calculation. `2` for binary-based numbers, any other Integer can be used. Defaults to `2`.
-- `output`: the ouput format to be used, possible options are :string, :list, :map. Defaults to :string.
-
-#### Example - Get file size for 1024 bytes
+### Get file size for 1024 bytes
 
 ```elixir
 Sizeable.filesize(1024)
 "1 KB"
 ```
 
-#### Example - Get bit-sized file size for 1024 bytes
+### Get bit-sized file size for 1024 bytes
 
 ```elixir
 Sizeable.filesize(1024, bits: true)
 "8 Kb"
 ```
 
-#### Example - Get output format as list
+### Get output format as list
 
 ```elixir
 Sizeable.filesize(1024, output: :list)
 [1, "KB"]
 ```
 
-#### Example - Get output format as map
+### Get output format as map
 
 ```elixir
 Sizeable.filesize(1024, output: :map)
 %{result: 1, unit: "KB"}
 ```
+
+Read [Sizeable.filesize/2](https://hexdocs.pm/sizeable) for further usage details.
+
+## Copyright and License
+
+Copyright (c) 2016 Arvid Kahl
+
+This software is licensed under [the MIT license](https://github.com/arvidkahl/sizeable/blob/master/LICENSE).

--- a/lib/sizeable.ex
+++ b/lib/sizeable.ex
@@ -1,7 +1,9 @@
 defmodule Sizeable do
-  @moduledoc """
-  A library to make file sizes human-readable
-  """
+  @external_resource "README.md"
+  @moduledoc "README.md"
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
 
   require Logger
 
@@ -9,7 +11,7 @@ defmodule Sizeable do
   @bytes ~w(B KB MB GB TB PB EB ZB YB)
 
   @doc """
-  see `filesize(value, options)`
+  See `filesize/2`.
   """
   def filesize(value) do
     filesize(value, [])
@@ -50,21 +52,26 @@ defmodule Sizeable do
 
   ## Arguments:
 
-  - `value` (Integer/Float/String) representing the filesize to be converted.
-  - `options` (Struct) representing the options to determine base, rounding and units.
+  * `value` (Integer/Float/String) representing the filesize to be converted.
+  * `options` (Struct) representing the options to determine base, rounding and units.
 
   ## Options
 
-  - `bits`: `true` if the result should be in bits, `false` if in bytes. Defaults to `false`.
-  - `spacer`: the string that should be between the number and the unit. Defaults to `" "`.
-  - `round`: the precision that the number should be rounded down to. Defaults to `2`.
-  - `base`: the base for exponent calculation. `2` for binary-based numbers, any other Integer can be used. Defaults to `2`.
-  - `output`: the ouput format to be used, possible options are :string, :list, :map. Defaults to :string.
+  * `:bits` - `true` if the result should be in bits, `false` if in bytes. Defaults to `false`.
+  * `:spacer` - the string that should be between the number and the unit. Defaults to `" "`.
+  * `:round` - the precision that the number should be rounded down to. Defaults to `2`.
+  * `:base` - the base for exponent calculation. `2` for binary-based numbers,
+    any other Integer can be used. Defaults to `2`.
+  * `:output` - the ouput format to be used, possible options are `:string`,
+    `:list`, or `:map`. Defaults to `:string`.
 
-  ## Example - Get bit-sized file size for 1024 byte
+  ## Examples
 
-    Sizeable.filesize(1024, bits: true)
-    "8 Kb"
+  Get bit-sized file size for 1024 byte.
+
+      Sizeable.filesize(1024, bits: true)
+      "8 Kb"
+
   """
   def filesize(value, options) when (is_float(value) and is_list(options)) do
     bits = Keyword.get(options, :bits, false)

--- a/mix.exs
+++ b/mix.exs
@@ -1,36 +1,50 @@
 defmodule Sizeable.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/arvidkahl/sizeable"
+
   def project do
-    [app: :sizeable,
-     version: "1.0.2",
-     elixir: "~> 1.1",
-     description: "An Elixir library to make file sizes human-readable.",
-     package: package(),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :sizeable,
+      version: "1.0.2",
+      elixir: "~> 1.1",
+      package: package(),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      docs: docs()
+    ]
   end
 
-  # Configuration for the OTP application
-
   def application do
-    [applications: [:logger]]
+    [
+      applications: [:logger]
+    ]
   end
 
   defp package do
     [
+      description: "An Elixir library to make file sizes human-readable.",
       maintainers: ["Arvid Kahl"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/arvidkahl/sizeable"},
       files: ["lib", "test", "mix.exs", "README*", "LICENSE*"],
+      links: %{"GitHub" => @source_url},
     ]
   end
 
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:inch_ex, only: :docs}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "Sizeable",
+      source_url: @source_url,
+      api_reference: false,
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,11 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+%{
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm", "db7b13d74a9edc54d3681762154d164d4a661cd27673cca80760344449877664"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.24.2", "e4c26603830c1a2286dae45f4412a4d1980e1e89dc779fcd0181ed1d5a05c8d9", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "e134e1d9e821b8d9e4244687fb2ace58d479b67b282de5158333b0d57c6fb7da"},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "7123ca0450686a61416a06cd38e26af18fd0f8c1cff5214770a957c6e0724338"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
+}


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main source doc for this Elixir
library which leverage on latest ExDoc features.

Screenshot:
![Screenshot-20210415233821-2682x1432](https://user-images.githubusercontent.com/134518/114897381-c16bd880-9e43-11eb-81d2-06ebe9d4b2d2.png)
