### PR TITLE
Fix Elixir 1.15+ warning

### DIFF
--- a/lib/sizeable.ex
+++ b/lib/sizeable.ex
@@ -18,7 +18,7 @@ defmodule Sizeable do
   end
 
   def filesize(value, options) when is_map(options) do
-    Logger.warn("Using maps for options is deprecated. Please use Keyword Lists.")
+    Logger.warning("Using maps for options is deprecated. Please use Keyword Lists.")
     filesize(value, Map.to_list(options))
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Sizeable.Mixfile do
     [
       app: :sizeable,
       version: "1.0.2",
-      elixir: "~> 1.1",
+      elixir: "~> 1.11",
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This fixes:

```
warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead (sizeable 1.0.2) lib/sizeable.ex:19: Sizeable.filesize/2
```

It also requires Elixir 1.11+ (the oldest still maintained Elixir version), so I bumped the requirement.